### PR TITLE
Fixes #7392: Missing python dependencies in rudder-tests docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ To run Rudder Test Framework, first prepare the needed tools:
 - install ruby 2
 - install jq
 - install serverspec http://serverspec.org/ (gem install serverspec)
+- install docopt, requests, pexpect and urllib3 python modules (pip install docopt requests pexpect urllib3)
 - run `make` in the `script` directory
 
 Run the desired test platform:


### PR DESCRIPTION
https://www.rudder-project.org/redmine/issues/7392