### PR TITLE
Fixes #7569: The chef/centos-7.0 box does not exist anymore

### DIFF
--- a/vagrant.rb
+++ b/vagrant.rb
@@ -23,7 +23,7 @@
 $centos5 = "hfm4/centos5"
 $centos6 = "geerlingguy/centos6"
 $centos6x32 = "kusold/centos-6-i386-puppet"
-$centos7 = "chef/centos-7.0"
+$centos7 = "bento/centos-7.1"
 
 $fedora18 = "boxcutter/fedora18"
 


### PR DESCRIPTION
http://www.rudder-project.org/redmine/issues/7569