### PR TITLE
Fixes #15541: rtf ncf_tests scenario doesn't fail when it fails to retrieve the ncf-setup script

### DIFF
--- a/scenario/ncf_tests.py
+++ b/scenario/ncf_tests.py
@@ -27,7 +27,7 @@ except:
   export_prefix = ""
 
 # Get setup_ncf
-shell_on("agent", "wget -O /tmp/ncf-setup https://repository.rudder.io/tools/ncf-setup", live_output=True)
+test_shell_on("agent", "wget -O /tmp/ncf-setup https://repository.rudder.io/tools/ncf-setup", live_output=True)
 
 # Get TAG
 tag = get_param("tag", "")


### PR DESCRIPTION
https://issues.rudder.io/issues/15541