### PR TITLE
Fixes #18396: Ubuntu18+ server requires at least 512Mb of ram to boot

### DIFF
--- a/platforms/ubuntu18.json
+++ b/platforms/ubuntu18.json
@@ -2,5 +2,5 @@
   "default":{ "rudder-version": "6.1", "system": "ubuntu18_04", "inventory-os": "ubuntu" },
   "server": { "rudder-setup": "server" },
   "relay":  { "rudder-setup": "relay" },
-  "agent1": { "rudder-setup": "agent", "server": "relay" }
+  "agent1": { "rudder-setup": "agent", "server": "relay", "ram": "512" }
 }

--- a/platforms/ubuntu20.json
+++ b/platforms/ubuntu20.json
@@ -2,5 +2,5 @@
   "default":{ "rudder-version": "6.1", "system": "ubuntu20_04", "inventory-os": "ubuntu" },
   "server": { "rudder-setup": "server" },
   "relay":  { "rudder-setup": "relay" },
-  "agent1": { "rudder-setup": "agent", "server": "relay" }
+  "agent1": { "rudder-setup": "agent", "server": "relay", "ram": "512" }
 }

--- a/platforms/ubuntu_all.json
+++ b/platforms/ubuntu_all.json
@@ -7,6 +7,6 @@
   "agent14": { "rudder-setup": "agent", "system": "ubuntu14_04" },
   "agent15_10": { "rudder-setup": "agent", "system": "ubuntu15_10" },
   "agent16": { "rudder-setup": "agent", "system": "ubuntu16_04" },
-  "agent18": { "rudder-setup": "agent", "system": "ubuntu18_04" },
-  "agent20": { "rudder-setup": "agent", "system": "ubuntu20_04" }
+  "agent18": { "rudder-setup": "agent", "system": "ubuntu18_04", "ram": "512" },
+  "agent20": { "rudder-setup": "agent", "system": "ubuntu20_04", "ram": "512" }
 }


### PR DESCRIPTION
https://issues.rudder.io/issues/18396