### PR TITLE
Fixes #18934: Rtf always print the network used when calling platform commands, which is not needed

### DIFF
--- a/lib/platform.py
+++ b/lib/platform.py
@@ -197,7 +197,6 @@ class Platform:
       for line in fd:
         m = re.match("^\$NETWORK\s*=\s*[\'\"](.*)[\'\"]", line)
         if bool(m):
-          print("Taking base network %s"%m.group(1))
           self.base_subnet = m.group(1)
 
   def pf_id_to_network(self, pf_id):


### PR DESCRIPTION
https://issues.rudder.io/issues/18934